### PR TITLE
Redirect home page to mixer page on load

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -5,7 +5,7 @@ import { createRoot } from "react-dom/client";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Index from "./pages/Index";
 import Compare from "./pages/Compare";
 import CompareIntro from "./pages/CompareIntro";
@@ -23,7 +23,7 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route path="/" element={<Navigate to="/mixer" replace />} />
           <Route path="/compare-intro" element={<CompareIntro />} />
           <Route path="/compare" element={<Compare />} />
           <Route path="/quiz-intro" element={<QuizIntro />} />


### PR DESCRIPTION
## Purpose

Based on user feedback, this change makes the website start directly on the mixer page instead of the default home page. This addresses the user's request to improve the initial landing experience by directing users to the mixer functionality immediately.

## Code changes

- Added `Navigate` import from `react-router-dom`
- Modified the root route (`/`) to redirect to `/mixer` using `<Navigate to="/mixer" replace />`
- Replaced the direct `<Index />` component rendering with the redirect navigationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df8d887a72764f0593ca075d352cb0a8/vortex-hub)

👀 [Preview Link](https://df8d887a72764f0593ca075d352cb0a8-vortex-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df8d887a72764f0593ca075d352cb0a8</projectId>-->
<!--<branchName>vortex-hub</branchName>-->